### PR TITLE
Paramètre Return-Path pour l'envoi des courriels

### DIFF
--- a/nqw/app/install.php
+++ b/nqw/app/install.php
@@ -132,6 +132,10 @@ try {
 			$erreurs .= HTML_LISTE_ERREUR_DEBUT . ERR_224 . HTML_LISTE_ERREUR_FIN;
 			$totErreurs++;
 		}
+		if (RETURN_PATH == "" || !filter_var(EMAIL_FROM, FILTER_VALIDATE_EMAIL)) {
+			$erreurs .= HTML_LISTE_ERREUR_DEBUT . ERR_238 . HTML_LISTE_ERREUR_FIN;
+			$totErreurs++;
+		}
 		
 		if ($totErreurs > 0) {
 			$messages = new Messages($erreurs, Messages::ERREUR);

--- a/nqw/config.inc.php
+++ b/nqw/config.inc.php
@@ -25,4 +25,7 @@ define('DB_PASSWORD', '');
 /** INSCRIRE ENTRE LES DEUX APOSTROPHES  ('') l’adresse de courriel qui figurera à titre d’expéditeur dans les courriels envoyés automatiquement par Netquiz Web aux utilisateurs (idéalement, cette adresse ne devrait pas être votre adresse personnelle, mais une adresse de courriel dédiée à Netquiz Web) */
 define('EMAIL_FROM', '');
 
+/** INSCRIRE ENTRE LES DEUX APOSTROPHES  ('') l’adresse de courriel qui figurera dans l'entête Return-Path indiquant à quelle adresse doivent être envoyées les réponses automatiques du serveur (no delivery par exemple). */
+define('RETURN_PATH', '');
+
 ?>

--- a/nqw/ressources/classes/outils/Courriel.php
+++ b/nqw/ressources/classes/outils/Courriel.php
@@ -50,14 +50,16 @@
 			
 			// Préparation des entêtes
 			$entetes = "From: \"Netquiz Web\" <" . EMAIL_FROM . ">\n"; 
-			$entetes .= "Reply-To: " . EMAIL_FROM > "\n"; 
+			$entetes .= "Reply-To: <" . EMAIL_FROM . ">\n"; 
 			$entetes .= "Content-Type: text/plain; charset=\"UTF-8\"\n"; 
 			$entetes .= "Content-Transfer-Encoding: 8bit"; 
+			
+			$parametres = "-f " . RETURN_PATH;
 			
 			// Envoi du courriel
 			try {
 				mb_language("uni"); 
-				if (mb_send_mail($dest, $sujet, $message, $entetes)) {
+				if (mb_send_mail($dest, $sujet, $message, $entetes, $parametres)) {
 					$succes = 1;
 				}
 			} catch (Exception $e) {

--- a/nqw/ressources/langues/nqw_en_CA.php
+++ b/nqw/ressources/langues/nqw_en_CA.php
@@ -1018,6 +1018,7 @@ define("ERR_234", "The XML tag 'texte' is invalid or missing.");
 define("ERR_235", "The XML tag 'url' is invalid or missing.");
 define("ERR_236", "This is not the correct file type.");
 define("ERR_237", "WARNING! One or more people are working on the same element as you. This could result in a loss of data if you save. If necessary, contact these people: ");
+define("ERR_238", "The RETURN_PATH parameter is missing or incorrect in the config.inc.php file.");
 
 /** URL pour l'aide en ligne **/
 define('URL_AIDE_NQW', 'http://aide.ccdmd.qc.ca/nqw/en/content/');

--- a/nqw/ressources/langues/nqw_fr_CA.php
+++ b/nqw/ressources/langues/nqw_fr_CA.php
@@ -1015,6 +1015,7 @@ define("ERR_234", "La balise XML &laquo;&nbsp;texte&nbsp;&raquo; est incorrecte 
 define("ERR_235", "La balise XML &laquo;&nbsp;url&nbsp;&raquo; est incorrecte ou absente.");
 define("ERR_236", "Le fichier n'est pas du bon type.");
 define("ERR_237", "DANGER! Une ou plusieurs personnes travaillent actuellement sur le même élément que vous. Cette situation pourrait entraîner des pertes de données si vous enregistrez au même moment. Veuillez contacter ces personnes au besoin&nbsp;: ");
+define("ERR_238", "Le paramètre RETURN_PATH du fichier de configuration &laquo;&nbsp;config.inc.php&nbsp;&raquo; est absent ou incorrect.");
 
 /** URL pour l'aide en ligne **/
 define('URL_AIDE_NQW', 'http://aide.ccdmd.qc.ca/nqw/fr/content/');


### PR DESCRIPTION
L'envoi des courriels par Netquiz Web ne fonctionne pas avec certains fournisseurs (par exemple : wanadoo.fr) qui exigent que l'entête "Return-Path" soit explicitement définie lors de l'envoi du courriel.
Pour éviter que les courriels soient refusés, un paramètre a été ajouté à mb_send_mail dans la fonction "envoiCourriel()" de la classe "ressources/classes/outils/Courriel.php" et une constante "RETURN_PATH" a été jaoutée dans le fichier "config.inc.php".
Les fichiers de langues et install.php ont aussi été modifiés pour prendre en compte la nouvelle constante "RETURN_PATH"
